### PR TITLE
feat: add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",


### PR DESCRIPTION
## Summary
- add `npm start` script so project can be launched with the common command

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 3 errors, 7 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7a83b284883308b72ad5e3c33e032