### PR TITLE
fix: serve assets from site root

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,8 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: "./",
+  // Serve assets from the domain root
+  base: "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- serve Vite build assets from the domain root

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm run build`
- `python3 -m http.server 5005 --directory dist` + `curl -I http://localhost:5005/` + `curl http://localhost:5005/ | grep assets` + `curl -I http://localhost:5005/assets/index-CWk7GxGA.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7f379455c8330b1975e34ead69913